### PR TITLE
Ensure the output directory exists

### DIFF
--- a/src/XliffForHtml/HtmlXliff.cs
+++ b/src/XliffForHtml/HtmlXliff.cs
@@ -150,7 +150,7 @@ namespace XliffForHtml
 
 			var file = _xliffDoc.CreateElement("file");
 			xliff.AppendChild(file);
-			file.SetAttribute("original", _originalFilename);
+			file.SetAttribute("original", Path.GetFileName(_originalFilename));
 			file.SetAttribute("datatype", "html");
 			file.SetAttribute("source-language", "en");
 

--- a/src/XliffForHtml/Program.cs
+++ b/src/XliffForHtml/Program.cs
@@ -107,6 +107,7 @@ namespace XliffForHtml
 				var xdoc = extractor.Extract();
 				if (outputFile == null)
 					outputFile = xliffFile;
+				EnsureOutputDirectoryExists(Path.GetDirectoryName(outputFile));
 				if (xdoc != null)
 					xdoc.Save(outputFile);
 				else
@@ -122,6 +123,7 @@ namespace XliffForHtml
 				var hdoc = injector.InjectTranslations(xliffFile, verboseWarnings);
 				if (outputFile == null)
 					outputFile = Path.ChangeExtension(xliffFile, ".html");
+				EnsureOutputDirectoryExists(Path.GetDirectoryName(outputFile));
 				if (outputFile == htmlFile)
 				{
 					Console.Write("Replace the input html file? [y/N] ");
@@ -134,6 +136,12 @@ namespace XliffForHtml
 					hdoc.Save(outputFile);
 				}
 			}
+		}
+
+		private static void EnsureOutputDirectoryExists(string directory)
+		{
+			if (!String.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+				Directory.CreateDirectory(directory);
 		}
 
 		private static void Usage()


### PR DESCRIPTION
Also simplify "original" attribute of the &lt;file&gt; element to the bare
filename to prevent gratuitous changes when extracted on different
developer machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/xliffforhtml/5)
<!-- Reviewable:end -->
