### PR TITLE
Fix check for markdown originals for Windows

### DIFF
--- a/src/XliffForHtml/HtmlXliff.cs
+++ b/src/XliffForHtml/HtmlXliff.cs
@@ -82,8 +82,8 @@ namespace XliffForHtml
 			// of runtime.  To prevent possible problems in managing Bloom translations, we preserve these two
 			// filenames as being markdown instead of HTML.  (This is what happens when people insist on flying the
 			// airplane while it's still being built...)
-			if (filename.EndsWith("/DistFiles/IntegrityFailureAdvice-en.htm") ||
-				filename.EndsWith("/DistFiles/infoPages/TrainingVideos-en.htm"))
+			if (filename.Replace("\\","/").EndsWith("/DistFiles/IntegrityFailureAdvice-en.htm") ||
+				filename.Replace("\\","/").EndsWith("/DistFiles/infoPages/TrainingVideos-en.htm"))
 			{
 				_originalFilename = Path.ChangeExtension(_originalFilename, "md");
 			}


### PR DESCRIPTION
This is needed before I can make regenerating the English xliff files part of the normal Bloom build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/xliffforhtml/11)
<!-- Reviewable:end -->
