### PR TITLE
Ensure UTF8 output for generated HTML files

### DIFF
--- a/src/XliffForHtml/Program.cs
+++ b/src/XliffForHtml/Program.cs
@@ -114,11 +114,11 @@ namespace XliffForHtml
 					Console.Write("Replace the input html file? [y/N] ");
 					var inline = Console.ReadLine();
 					if (inline.StartsWith("Y") || inline.StartsWith("y"))
-						hdoc.Save(outputFile);
+						hdoc.Save(outputFile, System.Text.Encoding.UTF8);
 				}
 				else
 				{
-					hdoc.Save(outputFile);
+					hdoc.Save(outputFile, System.Text.Encoding.UTF8);
 				}
 			}
 		}


### PR DESCRIPTION
This is needed to prevent garbled output on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/xliffforhtml/12)
<!-- Reviewable:end -->
