### PR TITLE
Handle \n in text properly on Windows

### DIFF
--- a/src/XliffForHtml/HtmlXliff.cs
+++ b/src/XliffForHtml/HtmlXliff.cs
@@ -291,6 +291,11 @@ namespace XliffForHtml
 				if (node.NodeType == HtmlNodeType.Text)
 				{
 					var text = HttpUtility.HtmlDecode(node.InnerText);
+					// markdown-it produces files with \n line endings even on Windows from
+					// input files that use \r\n line endings.  We need to maintain \r\n line
+					// ending throughout the xliff file on Windows, even in quoted text.
+					if (text != null && text.Contains("\n") && !text.Contains(Environment.NewLine))
+						text = text.Replace("\n", Environment.NewLine);
 					var tn = _xliffDoc.CreateTextNode(text);
 					newXliffElement.AppendChild(tn);
 				}

--- a/src/XliffForHtml/Program.cs
+++ b/src/XliffForHtml/Program.cs
@@ -132,8 +132,8 @@ namespace XliffForHtml
 		private static void Usage()
 		{
 			Console.WriteLine("Usage: HtmlXliff [options] htmlfile");
-			Console.WriteLine("       -e|--extract = extract translations from xliff file [default]");
-			Console.WriteLine("       -i|--inject = inject translations from xliff file");
+			Console.WriteLine("       -e|--extract = extract strings to translate from html file [default]");
+			Console.WriteLine("       -i|--inject = inject translations from xliff file to create translated html file");
 			Console.WriteLine("       -v|--verbose = display warnings for missing translations (ignored if extracting)");
 			Console.WriteLine("       -f|--folder <lang> = the xliff file is in a subfolder named <lang> (ignored if -x or -o specified)");
 			Console.WriteLine("       -x|--xliff <file> = specify xliff file path (ignored if extracting and -o specified)");


### PR DESCRIPTION
Also correct and clarify the usage message for command line options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/xliffforhtml/14)
<!-- Reviewable:end -->
